### PR TITLE
CI integration using Github Actions

### DIFF
--- a/.github/workflows/ci-cmake.yml
+++ b/.github/workflows/ci-cmake.yml
@@ -1,0 +1,40 @@
+name: CI-CMake
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        build-type: [Debug]
+        python:
+          - 3.6
+
+    name: "Build: ${{matrix.os}} • ${{matrix.python}} • ${{matrix.build-type}}"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{matrix.python}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python}}
+
+    - name: Prepare Python Environment
+      run: python -m pip install -r requirements.txt
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -1,4 +1,4 @@
-name: CI-CMake
+name: ci-linux
 
 on:
   push:
@@ -12,9 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        build-type: [Debug]
+        build-type: [Release, Debug, RelWithDebInfo]
         python:
           - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
 
     name: "Build: ${{matrix.os}} • ${{matrix.python}} • ${{matrix.build-type}}"
     runs-on: ${{matrix.os}}

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,43 @@
+name: ci-macos
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        build-type: [Release, Debug, RelWithDebInfo]
+        python:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+
+    name: "Build: ${{matrix.os}} • ${{matrix.python}} • ${{matrix.build-type}}"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{matrix.python}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python}}
+
+    - name: Prepare Python Environment
+      run: python -m pip install -r requirements.txt
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,0 +1,43 @@
+name: ci-windows
+
+on:
+  push:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        build-type: [Release, Debug, RelWithDebInfo]
+        python:
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+
+    name: "Build: ${{matrix.os}} • ${{matrix.python}} • ${{matrix.build-type}}"
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python ${{matrix.python}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python}}
+
+    - name: Prepare Python Environment
+      run: python -m pip install -r requirements.txt
+
+    - name: Update CMake
+      uses: jwlawson/actions-setup-cmake@v1.10
+
+    - name: Configure CMake
+      run: cmake -S . -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}}
+
+    - name: Build C++ Project
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build-type}}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Tiny-Utils
 
 A small set of C/C++ helper functionality that is used alongside various of my projects
+
+## Build Status
+
+| Build   | Status                                                                                                                                                                      |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ubuntu  | [![ci-linux](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-linux.yml/badge.svg)](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-linux.yml)       |
+| Windows | [![ci-windows](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-windows.yml/badge.svg)](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-windows.yml) |
+| MacOS   | [![ci-macos](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-macos.yml/badge.svg)](https://github.com/wpumacay/tiny_utils/actions/workflows/ci-macos.yml)       |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 setuptools
+ninja
 pytest


### PR DESCRIPTION
This PR is meant to keep track of the support for CI using `Github Actions`. The main workflows we'll have to support are the following:

- [x] CI for checking the integrity of the CMake-based builds
- [ ] CI for checking the integrity of the Setuptools-based builds
- [ ] CD for deploying the generated Source Distribution to PyPI
- [ ] CI for generating the documentation (Doxygen+Sphinx+Breathe)